### PR TITLE
Account for filenames with multiple `.` dots

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,22 +2,35 @@ import { basename, dirname, join } from 'path'
 import { commands, ExtensionContext, FileType, Uri, window, workspace } from 'vscode'
 
 function getCopyName(original: string): [string, number] {
-	const split = original.split('.', 2)
-	const hasName = split[0].length > 0
+	const lastIndex = original.lastIndexOf('.');
+	let name = original.slice(0, lastIndex);
+	let ext = original.slice(lastIndex + 1);
 
-	let name = split[0]
-	let ext = split.length === 2 ? '.' + split[1] : ''
-
-	if (hasName) {
+	if (lastIndex !== 0) {
 		name += '-copy'
 	}
 	else {
 		ext += '-copy'
 	}
 
+	let newName;
+	let newLength;
+
+	if (lastIndex == -1) {
+		newName = name;
+		newLength = newName.length;
+	}
+	else if (lastIndex == 0) {
+		newName = '.' + ext;
+		newLength = newName.length;
+	} else {
+		newName = name + '.' + ext;
+		newLength = name.length;
+	}
+
 	return [
-		name + ext,
-		name.length
+		newName,
+		newLength
 	]
 }
 


### PR DESCRIPTION
Changes the logic to account for filenames that contain additional `.` dots/full stops

This may be quite unusual/specific, but I work daily with files that have filenames such as `1.1.1_text-alternative.md` (which refer to a specific [WCAG 2.1](https://www.w3.org/TR/WCAG21) Success Criterion, in this case [`1.1.1 Non-text Content`](https://www.w3.org/TR/WCAG21/#non-text-content)).

Currently, using the extension, the default new filename for the duplicate comes out as `1-copy.1`. With this patch, it comes out correctly as `1.1.1_text-alternative-copy.md`.

It also still works as it should with dotfiles `.htaccess` -> `.htaccess-copy`, and even files without any dot at all like `LICENSE` -> `LICENSE-copy`.